### PR TITLE
fix issue - "Signature does not match request parameters."

### DIFF
--- a/cryptopia_api.py
+++ b/cryptopia_api.py
@@ -165,7 +165,7 @@ class Api(object):
         """ Creates secure header for cryptopia private api. """
         nonce = str(int(time.time()))
         md5 = hashlib.md5()
-        jsonparams = json.dumps(post_data).encode('utf-8')
+        jsonparams = post_data.encode('utf-8')
         md5.update(jsonparams)
         rcb64 = base64.b64encode(md5.digest()).decode('utf-8')
         


### PR DESCRIPTION
In api_query() we are already dumping post_parameters, so we shouldn't do it twice