### PR TITLE
Remove int rounding

### DIFF
--- a/cryptopia_api.py
+++ b/cryptopia_api.py
@@ -163,7 +163,7 @@ class Api(object):
 
     def secure_headers(self, url, post_data):
         """ Creates secure header for cryptopia private api. """
-        nonce = str(int(time.time()))
+        nonce = str(time.time() )
         md5 = hashlib.md5()
         jsonparams = post_data.encode('utf-8')
         md5.update(jsonparams)


### PR DESCRIPTION
By removing this int() rounding, the error "Nonce has already been used for this request" no longer happens when applying more than one order under one second.
I've been using this for more than 24 ours with no aparent side effects.